### PR TITLE
Pablo

### DIFF
--- a/Ext/GeometryStack/Generators/AlembicGeometryGenerator.kl
+++ b/Ext/GeometryStack/Generators/AlembicGeometryGenerator.kl
@@ -166,7 +166,14 @@ function AlembicGeometryGenerator.evaluate!(EvalContext context, io GeometrySet 
 
     // Compute the global transform for this sample and save it as meta data. 
 
-    Xfo globalXfo = this.computeGlobalXfo(this.time, archive, polymeshPaths[i]);
+    // TODO: This is a temporary hack because FE 2.0 was giving errors that it was reading Xfo
+    //       from PolyMesh instead of Xfo. Not sure if this is the correct 'fix'
+    // Get the transform from the PolygonMesh (parent transform)
+    String hierarchy[] = polymeshPaths[i].split("/");
+    hierarchy.pop(); // Remove the shape item
+    String transform = "/".join(hierarchy);
+
+    Xfo globalXfo = this.computeGlobalXfo(this.time, archive, transform);
     Mat44Param globalTransform('globalTransform', globalXfo.toMat44());
     AutoLock AL(mesh.metaData.simpleLock);
     mesh.metaData.lockedSet('globalTransform', globalTransform);

--- a/Ext/GeometryStack/Generators/AlembicGeometryGenerator.kl
+++ b/Ext/GeometryStack/Generators/AlembicGeometryGenerator.kl
@@ -96,7 +96,7 @@ inline String AlembicGeometryGenerator.getFilePath(){
 /// \internal
 inline String AlembicGeometryGenerator.getNameFromPath(String pathStr) {
   String path[] = pathStr.split('/');
-  return path[path.size-1];
+  return path[path.size()-1];
 }
 
 
@@ -105,7 +105,7 @@ inline String AlembicGeometryGenerator.getNameFromPath(String pathStr) {
 function String AlembicGeometryGenerator.getParentPath(String pathStr) {
   String path[] = pathStr.split('/');
   String parentPath;
-  for(Integer j=0; j<path.size-1; j++){
+  for(Integer j=0; j<path.size()-1; j++){
     if(j==0)
       parentPath = path[j];
     else
@@ -155,7 +155,7 @@ function AlembicGeometryGenerator.evaluate!(EvalContext context, io GeometrySet 
     String name = this.getNameFromPath(polymeshPaths[i]);
     
     // Only include the geomety if it matches the name filters. (or there are no name filters)
-    if(this.geometryNames.size != 0 && !applyNameFilters(name, this.geometryNames))
+    if(this.geometryNames.size() != 0 && !applyNameFilters(name, this.geometryNames))
       continue;
 
     readers[i] = archive.getPolyMesh(polymeshPaths[i]);
@@ -192,7 +192,7 @@ function JSONDictValue AlembicGeometryGenerator.saveJSON(PersistenceContext pers
   json.setString('filePath', this.filePath);
 
   JSONArrayValue geometryNamesData();
-  for(Integer i=0; i<this.geometryNames.size; i++)
+  for(Integer i=0; i<this.geometryNames.size(); i++)
     geometryNamesData.addString(this.geometryNames[i]);
   json.set('geometryNames', geometryNamesData);
 

--- a/Ext/GeometryStack/Generators/AlembicGeometryGenerator.kl
+++ b/Ext/GeometryStack/Generators/AlembicGeometryGenerator.kl
@@ -104,14 +104,8 @@ inline String AlembicGeometryGenerator.getNameFromPath(String pathStr) {
 /// \internal
 function String AlembicGeometryGenerator.getParentPath(String pathStr) {
   String path[] = pathStr.split('/');
-  String parentPath;
-  for(Integer j=0; j<path.size()-1; j++){
-    if(j==0)
-      parentPath = path[j];
-    else
-      parentPath = parentPath + "/" + path[j];
-  }
-  return parentPath;
+  path.pop();
+  return "/".join(path);
 }
 
 /// computes the global transform of an item in the alembic hierarchy./
@@ -164,15 +158,10 @@ function AlembicGeometryGenerator.evaluate!(EvalContext context, io GeometrySet 
     mesh.debugName = name; // Set the debug name so we can easily track this geom in future. 
     readers[i].readSample(this.time, mesh);
 
-    // Compute the global transform for this sample and save it as meta data. 
-
-    // TODO: This is a temporary hack because FE 2.0 was giving errors that it was reading Xfo
-    //       from PolyMesh instead of Xfo. Not sure if this is the correct 'fix'
     // Get the transform from the PolygonMesh (parent transform)
-    String hierarchy[] = polymeshPaths[i].split("/");
-    hierarchy.pop(); // Remove the shape item
-    String transform = "/".join(hierarchy);
+    String transform = this.getParentPath(polymeshPaths[i]);
 
+    // Compute the global transform for this sample and save it as meta data. 
     Xfo globalXfo = this.computeGlobalXfo(this.time, archive, transform);
     Mat44Param globalTransform('globalTransform', globalXfo.toMat44());
     AutoLock AL(mesh.metaData.simpleLock);

--- a/Ext/GeometryStack/Generators/AlembicSkinnedMeshGeometryGenerator.kl
+++ b/Ext/GeometryStack/Generators/AlembicSkinnedMeshGeometryGenerator.kl
@@ -197,7 +197,7 @@ inline String AlembicSkinnedMeshGeometryGenerator.getFilePath(){
 /// \internal
 inline String AlembicSkinnedMeshGeometryGenerator.getNameFromPath(String pathStr) {
   String path[] = pathStr.split('/');
-  return path[path.size-1];
+  return path[path.size()-1];
 }
 
 /// Returns the parent path for any alembic path
@@ -205,7 +205,7 @@ inline String AlembicSkinnedMeshGeometryGenerator.getNameFromPath(String pathStr
 function String AlembicSkinnedMeshGeometryGenerator.getParentPath(String pathStr) {
   String path[] = pathStr.split('/');
   String parentPath;
-  for(Integer j=0; j<path.size-1; j++){
+  for(Integer j=0; j<path.size()-1; j++){
     if(j==0)
       parentPath = path[j];
     else
@@ -217,7 +217,7 @@ function String AlembicSkinnedMeshGeometryGenerator.getParentPath(String pathStr
 /// Finds and item in the list with the given path.
 /// \internal
 function Integer AlembicSkinnedMeshGeometryGenerator.findItem(String list[], String item) {
-  for(Integer j=0; j<list.size; j++){
+  for(Integer j=0; j<list.size(); j++){
     if(item == list[j])
       return j;
   }
@@ -228,7 +228,7 @@ function Integer AlembicSkinnedMeshGeometryGenerator.findItem(String list[], Str
 /// \internal
 function Integer AlembicSkinnedMeshGeometryGenerator.findItemInNameList(String namesList[], String pathStr) {
   String name = this.getNameFromPath(pathStr);
-  for(Integer j=0; j<namesList.size; j++){
+  for(Integer j=0; j<namesList.size(); j++){
     if(name == namesList[j])
       return j;
   }
@@ -239,9 +239,9 @@ function Integer AlembicSkinnedMeshGeometryGenerator.findItemInNameList(String n
 /// Merges 2 sets giving a new set with unique members
 /// \internal
 function AlembicSkinnedMeshGeometryGenerator.mergeSet(io String set[], String merge[]) {
-  for(Integer i=0; i<merge.size; i++){
+  for(Integer i=0; i<merge.size(); i++){
     Boolean found = false;
-    for(Integer j=0; j<set.size; j++)
+    for(Integer j=0; j<set.size(); j++)
       if(merge[i] == set[j])
         found = true;
     if(!found)
@@ -265,7 +265,7 @@ function AlembicSkinnedMeshGeometryGenerator.collectAncestralHierarchy(String pa
 /// Collects all items in the hierachy below the given item and adds them to the list
 /// \internal
 function AlembicSkinnedMeshGeometryGenerator.collectDescendantHierarchy(String pathStr, String paths[], io String list[]) {
-  for(Integer i=0; i<paths.size; i++){
+  for(Integer i=0; i<paths.size(); i++){
     // Alembic paths are hierarchical, so any path starting with the given path is a child.
     if(paths[i].startsWith(pathStr) && this.findItem(list, paths[i]) == -1){
       list.push(paths[i]);
@@ -317,8 +317,8 @@ function Float32[] AlembicSkinnedMeshGeometryGenerator_loadFloat32ArrayProperty(
   Float32 result[];
   if(header.getDataType().getPod() == Alembic_kFloat64POD){
     Float64 temp[] = AlembicIFloat64ArrayProperty(compound, prop).get();
-    result.resize(temp.size);
-    for(UInt32 w=0; w<temp.size; w++)
+    result.resize(temp.size());
+    for(UInt32 w=0; w<temp.size(); w++)
       result[w] = Float32(temp[w]);
   }
   else if(header.getDataType().getPod() == Alembic_kFloat32POD)
@@ -331,20 +331,20 @@ function UInt32[] AlembicSkinnedMeshGeometryGenerator_loadUInt32ArrayProperty( A
   UInt32 result[];
   if(header.getDataType().getPod() == Alembic_kInt64POD){
     SInt64 temp[] = AlembicISInt64ArrayProperty(compound, prop).get();
-    result.resize(temp.size);
-    for(UInt32 w=0; w<temp.size; w++)
+    result.resize(temp.size());
+    for(UInt32 w=0; w<temp.size(); w++)
       result[w] = UInt32(temp[w]);
   }
   else if(header.getDataType().getPod() == Alembic_kUint64POD){
     SInt64 temp[] = AlembicISInt64ArrayProperty(compound, prop).get();
-    result.resize(temp.size);
-    for(UInt32 w=0; w<temp.size; w++)
+    result.resize(temp.size());
+    for(UInt32 w=0; w<temp.size(); w++)
       result[w] = UInt32(temp[w]);
   }
   else if(header.getDataType().getPod() == Alembic_kInt32POD){
     SInt32 temp[] = AlembicISInt32ArrayProperty(compound, prop).get();
-    result.resize(temp.size);
-    for(UInt32 w=0; w<temp.size; w++)
+    result.resize(temp.size());
+    for(UInt32 w=0; w<temp.size(); w++)
       result[w] = UInt32(temp[w]);
   }
   else if(header.getDataType().getPod() == Alembic_kInt32POD)
@@ -400,7 +400,7 @@ function AlembicSkinnedMeshGeometryGenerator.evaluate!(EvalContext context, io G
   for(Size i=0; i<polymeshPaths.size(); i++) {
     String name = this.getNameFromPath(polymeshPaths[i]);
     
-    if(this.geometryNames.size != 0 && !applyNameFilters(name, this.geometryNames))
+    if(this.geometryNames.size() != 0 && !applyNameFilters(name, this.geometryNames))
       continue;
 
     readers[i] = archive.getPolyMesh(polymeshPaths[i]);
@@ -442,7 +442,7 @@ function AlembicSkinnedMeshGeometryGenerator.evaluate!(EvalContext context, io G
       }
     }
 
-    if(deformerNames.size==0){
+    if(deformerNames.size()==0){
       continue;
     }
 
@@ -455,8 +455,8 @@ function AlembicSkinnedMeshGeometryGenerator.evaluate!(EvalContext context, io G
     // while also traversing up the hierarchy and collecting the entire
     // hierarchy. This is because the skeleton must represent the entire
     // transformation from the scene root to each deformer in the skeleton. 
-    deformerXformIds[i].resize(deformerNames.size);
-    for(Integer j=0; j<deformerNames.size; j++){
+    deformerXformIds[i].resize(deformerNames.size());
+    for(Integer j=0; j<deformerNames.size(); j++){
       Integer index = this.findItem(xformNames, deformerNames[j]);
       if(index >= 0){
         // Store the index of the deformer in the deformerXformIds array
@@ -486,11 +486,11 @@ function AlembicSkinnedMeshGeometryGenerator.evaluate!(EvalContext context, io G
   }
 
   // There might be xforms specified in the file that must be 
-  for (Integer i=0; i<this.includedSubtrees.size; i++){
+  for (Integer i=0; i<this.includedSubtrees.size(); i++){
     this.includeTree(this.includedSubtrees[i], xformPaths, skeletonBonePaths);
   }
 
-  if(skeletonBonePaths.size == 0)
+  if(skeletonBonePaths.size() == 0)
     return;
 
   //-----------------------------------------
@@ -544,8 +544,8 @@ function AlembicSkinnedMeshGeometryGenerator.evaluate!(EvalContext context, io G
             envelopeWeights = AlembicIFloat32ArrayProperty(envWeightsCpmd, 'vals').get();
 
             UInt32 temp[] = AlembicIUInt32ArrayProperty(envWeightsCpmd , "subArrayIndices").get();
-            subArrayIndices.resize(temp.size/2);
-            for(Integer j=0; j<subArrayIndices.size; j++)
+            subArrayIndices.resize(temp.size()/2);
+            for(Integer j=0; j<subArrayIndices.size(); j++)
               subArrayIndices[j] = temp[j*2];
           }
           else
@@ -556,8 +556,8 @@ function AlembicSkinnedMeshGeometryGenerator.evaluate!(EvalContext context, io G
           if (header.isCompound()){
             AlembicICompoundProperty mappingIndicesCpmd = AlembicICompoundProperty(compound, propname);
             SInt32 temp[] = AlembicISInt32ArrayProperty(mappingIndicesCpmd , "vals").get();
-            subArrayIndices.resize(temp.size);
-            for(UInt32 w=0; w<temp.size; w++)
+            subArrayIndices.resize(temp.size());
+            for(UInt32 w=0; w<temp.size(); w++)
               subArrayIndices[w] = UInt32(temp[w]);
             // subArrayIndices = AlembicSkinnedMeshGeometryGenerator_loadUInt32ArrayProperty(mappingIndicesCpmd, header, "vals");
           }
@@ -569,8 +569,8 @@ function AlembicSkinnedMeshGeometryGenerator.evaluate!(EvalContext context, io G
           if (header.isCompound()){
             AlembicICompoundProperty envDefIdCpmd = AlembicICompoundProperty(compound, propname);
             SInt32 temp[] = AlembicISInt32ArrayProperty(envDefIdCpmd , "vals").get();
-            envelopeDeformerIndices.resize(temp.size);
-            for(UInt32 w=0; w<temp.size; w++)
+            envelopeDeformerIndices.resize(temp.size());
+            for(UInt32 w=0; w<temp.size(); w++)
               envelopeDeformerIndices[w] = UInt32(temp[w]);
             // envelopeDeformerIndices = AlembicSkinnedMeshGeometryGenerator_loadUInt32ArrayProperty(envDefIdCpmd, header, "vals");
           }
@@ -579,23 +579,23 @@ function AlembicSkinnedMeshGeometryGenerator.evaluate!(EvalContext context, io G
           break;
       }
     }
-    if(envelopeWeights.size == 0)
+    if(envelopeWeights.size() == 0)
       continue;
 
-    if(mesh.pointCount() != subArrayIndices.size){
+    if(mesh.pointCount() != subArrayIndices.size()){
       String name = this.getNameFromPath(polymeshPaths[i]);
-      report("Warning: Invalid skinning data on mesh:'"+name+"'. The skinning data count doesn't match the PolygonMesh point count. mesh.pointCount():" + mesh.pointCount() + " != subArrayIndices.size:" + subArrayIndices.size);
+      report("Warning: Invalid skinning data on mesh:'"+name+"'. The skinning data count doesn't match the PolygonMesh point count. mesh.pointCount():" + mesh.pointCount() + " != subArrayIndices.size:" + subArrayIndices.size());
       continue;
     }
 
     UInt32 thisGeom_deformerXformIds[] = deformerXformIds[skinnedGeometryIndices[i]];
-    UInt32 nbBones = thisGeom_deformerXformIds.size;
-    UInt32 nbPoints = subArrayIndices.size;
+    UInt32 nbBones = thisGeom_deformerXformIds.size();
+    UInt32 nbPoints = subArrayIndices.size();
     Integer boneMapping[];
     boneMapping.resize(nbBones);
     // Now, for each deformer listed on this geometry, find its index in the deformers union.
     // It will be the union of deformers that will be used as a single pose in the skinning modifier. 
-    for(Integer j=0; j<thisGeom_deformerXformIds.size; j++) {
+    for(Integer j=0; j<thisGeom_deformerXformIds.size(); j++) {
       Integer index = this.findItem(sortedDeformerNames, xformNames[thisGeom_deformerXformIds[j]]);
       if(index >= 0){
         boneMapping[j] = index;
@@ -609,7 +609,7 @@ function AlembicSkinnedMeshGeometryGenerator.evaluate!(EvalContext context, io G
     UInt32 usedWeights = 0;
     for(Integer pnt = 0; pnt < nbPoints; pnt++ ) {
       UInt32 startIndex = subArrayIndices[pnt];
-      UInt32 deformerCount = ((pnt < (nbPoints-1)) ? subArrayIndices[pnt+1] : envelopeWeights.size) - startIndex;
+      UInt32 deformerCount = ((pnt < (nbPoints-1)) ? subArrayIndices[pnt+1] : envelopeWeights.size()) - startIndex;
 
       LocalL16UInt32Array indices;
       LocalL16ScalarArray weights;
@@ -649,8 +649,8 @@ function Skeleton AlembicSkinnedMeshGeometryGenerator.buildSkeleton(io AlembicAr
   Bone bones[];
   Boolean visibleBones[];
 
-  visibleBones.resize(skeletonBonePaths.size);
-  bones.resize(skeletonBonePaths.size);
+  visibleBones.resize(skeletonBonePaths.size());
+  bones.resize(skeletonBonePaths.size());
 
   for(Index i=0;i<skeletonBonePaths.size();i++) {
     String name = this.getNameFromPath(skeletonBonePaths[i]);
@@ -847,12 +847,12 @@ function JSONDictValue AlembicSkinnedMeshGeometryGenerator.saveJSON(PersistenceC
   json.setString('filePath', this.filePath);
 
   JSONArrayValue geometryNamesData();
-  for(Integer i=0; i<this.geometryNames.size; i++)
+  for(Integer i=0; i<this.geometryNames.size(); i++)
     geometryNamesData.addString(this.geometryNames[i]);
   json.set('geometryNames', geometryNamesData);
 
   JSONArrayValue includedSubtreesData();
-  for(Integer i=0; i<this.includedSubtrees.size; i++)
+  for(Integer i=0; i<this.includedSubtrees.size(); i++)
     includedSubtreesData.addString(this.includedSubtrees[i]);
   json.set('includedSubtrees', includedSubtreesData);
 

--- a/Ext/GeometryStack/Generators/AlembicSkinnedMeshGeometryGenerator.kl
+++ b/Ext/GeometryStack/Generators/AlembicSkinnedMeshGeometryGenerator.kl
@@ -204,14 +204,8 @@ inline String AlembicSkinnedMeshGeometryGenerator.getNameFromPath(String pathStr
 /// \internal
 function String AlembicSkinnedMeshGeometryGenerator.getParentPath(String pathStr) {
   String path[] = pathStr.split('/');
-  String parentPath;
-  for(Integer j=0; j<path.size()-1; j++){
-    if(j==0)
-      parentPath = path[j];
-    else
-      parentPath = parentPath + "/" + path[j];
-  }
-  return parentPath;
+  path.pop();
+  return "/".join(path);
 }
 
 /// Finds and item in the list with the given path.
@@ -409,15 +403,10 @@ function AlembicSkinnedMeshGeometryGenerator.evaluate!(EvalContext context, io G
     mesh.debugName = name; // Set the debug name so we can easily track this geom in future. 
     readers[i].readSample(0.0, mesh);
 
-    // TODO: This is a temporary hack because FE 2.0 was giving errors that it was reading Xfo
-    //       from PolyMesh instead of Xfo. Not sure if this is the correct 'fix'
     // Get the transform from the PolygonMesh (parent transform)
-    String hierarchy[] = polymeshPaths[i].split("/");
-    hierarchy.pop(); // Remove the shape item
-    String transform = "/".join(hierarchy);
+    String transform = this.getParentPath(polymeshPaths[i]);
 
     Xfo globalXfo = this.computeGlobalXfo(archive, transform);
-
     Mat44Param globalTransform('globalTransform', globalXfo.toMat44());
     AutoLock AL(mesh.metaData.simpleLock);
     mesh.metaData.lockedSet('globalTransform', globalTransform);

--- a/Ext/GeometryStack/Generators/AlembicSkinnedMeshGeometryGenerator.kl
+++ b/Ext/GeometryStack/Generators/AlembicSkinnedMeshGeometryGenerator.kl
@@ -409,8 +409,14 @@ function AlembicSkinnedMeshGeometryGenerator.evaluate!(EvalContext context, io G
     mesh.debugName = name; // Set the debug name so we can easily track this geom in future. 
     readers[i].readSample(0.0, mesh);
 
+    // TODO: This is a temporary hack because FE 2.0 was giving errors that it was reading Xfo
+    //       from PolyMesh instead of Xfo. Not sure if this is the correct 'fix'
+    // Get the transform from the PolygonMesh (parent transform)
+    String hierarchy[] = polymeshPaths[i].split("/");
+    hierarchy.pop(); // Remove the shape item
+    String transform = "/".join(hierarchy);
 
-    Xfo globalXfo = this.computeGlobalXfo(archive, polymeshPaths[i]);
+    Xfo globalXfo = this.computeGlobalXfo(archive, transform);
 
     Mat44Param globalTransform('globalTransform', globalXfo.toMat44());
     AutoLock AL(mesh.metaData.simpleLock);

--- a/Ext/GeometryStack/GeometryAttributeCache.kl
+++ b/Ext/GeometryStack/GeometryAttributeCache.kl
@@ -43,8 +43,8 @@ function GeometryAttributeCache.update!(io GeometrySet geomSet, GeometryOperator
   AutoProfilingEvent p(FUNC+":"+this.attributesNames);
 
 
-  UInt32 numGeoms = geomSet.size;
-  UInt32 numcachedAttrs = this.attributesNames.size;
+  UInt32 numGeoms = geomSet.size();
+  UInt32 numcachedAttrs = this.attributesNames.size();
   this.cachedAttributes.resize(numGeoms);
   this.attributeGenerations.resize(numGeoms);
 

--- a/Ext/GeometryStack/GeometryHelperFunctions.kl
+++ b/Ext/GeometryStack/GeometryHelperFunctions.kl
@@ -241,7 +241,7 @@ function Boolean applyNameFilter(String name, String filter){
 
 
 function Boolean applyNameFilters(String name, String filters[]){
-  for(Integer i=0; i<filters.size; i++){
+  for(Integer i=0; i<filters.size(); i++){
     if(applyNameFilter(name, filters[i])){
       return true;
     }

--- a/Ext/GeometryStack/GeometryOperator.kl
+++ b/Ext/GeometryStack/GeometryOperator.kl
@@ -11,14 +11,14 @@ const UInt32 AttrMode_ReadWrite = 2;
 
 
 /**
-  A GeometryOperator is can generate or modify geomety in the geometry stack.
-  The GeometryStack manages a sequence of these operators, evalauting and caching thier results during scene playback. 
+  A GeometryOperator can generate or modify geomety in the geometry stack.
+  The GeometryStack manages a sequence of these operators, evaluating and caching thier results during scene playback. 
 
   \seealso GeometryOperator, RiggingToolboxRegistry, GeometryStack
 */
 interface GeometryOperator {
   
-  // returns the list of attributes that the geomery operator is interacting with in some way. 
+  // Returns the list of attributes that the geomery operator is interacting with in some way. 
   // Generators will usually write a collection of attributes, while Modifiers will read and write 
   // attributes. This dictionary is used to determine where caching should occur in the geometry stack.
   UInt32[String] getAttributeInteractions();

--- a/Ext/GeometryStack/GeometrySet.kl
+++ b/Ext/GeometryStack/GeometrySet.kl
@@ -83,7 +83,7 @@ function String GeometrySet.getDesc(String indent, Boolean includeGeometryTolopo
   String desc;
   desc += indent + "{ \n";
   desc += indent + "  geometries:[ \n";
-  for(Integer i=0; i<this.size; i++){
+  for(Integer i=0; i<this.size(); i++){
     desc += indent + "    " + getGeomDebugName(this.get(i)) + ":{\n";
     
     if(includeGeometryTolopology){

--- a/Ext/GeometryStack/GeometryStack.kl
+++ b/Ext/GeometryStack/GeometryStack.kl
@@ -119,6 +119,10 @@ function GeometryStack.notify!(Notifier notifier, String type, String data) {
 function GeometrySet GeometryStack.evaluate!(EvalContext context) {
   AutoProfilingEvent p(FUNC);
 
+  // Report meaningful error if context is null
+  if (context == null)
+    throw("Context is null. Ensure an initialized EvalContext is passed.");
+
   // this.dirtyPoint = 0;// force evaluation all the time.(disable caching)
   if(this.dirtyPoint < this.geomOperators.size()){
     for(Integer i=this.dirtyPoint; i<this.geomOperators.size(); i++){
@@ -151,8 +155,12 @@ function GeometrySet GeometryStack.evaluate!(EvalContext context) {
         Generator generator = op;
         if(generator)
           cachePoint = GeometryCache();
-        else
-          cachePoint = GeometryAttributeCache(op);
+        else // modifier
+        {
+          // #8 Bugfix: Explicit type cast for interfaces in KL, otherwise GeometryAttributeCache returns null
+          BaseModifier mod = op; 
+          cachePoint = GeometryAttributeCache(mod);
+        }
         this.cachePoints[i] = cachePoint;
       }
 

--- a/Ext/GeometryStack/GeometryStack.kl
+++ b/Ext/GeometryStack/GeometryStack.kl
@@ -68,7 +68,7 @@ function GeometryStack.addAttributeDependency!(String from, String to) {
 
 function GeometryStack.addGeometryOperator!(GeometryOperator op) {
   this.geomOperators.push(op);
-  this.cachePoints.resize(this.geomOperators.size);
+  this.cachePoints.resize(this.geomOperators.size());
 
   // Note: the cast causes the 'in' arg to become 'io' here.
   Notifier notifier = op;
@@ -83,7 +83,7 @@ function GeometryOperator GeometryStack.getGeometryOperator(UInt32 index) {
 
 
 function UInt32 GeometryStack.numGeometryOperators() {
-  return this.geomOperators.size;
+  return this.geomOperators.size();
 }
 
 // Recieves a notification from one of the notifiers. 
@@ -92,12 +92,12 @@ function GeometryStack.notify!(Notifier notifier, String type, String data) {
   AutoProfilingEvent p(FUNC+":" + notifier.type() + "." +type);
   switch(type){
   case 'changed':
-    for(Integer i=0; i<this.geomOperators.size; i++){
+    for(Integer i=0; i<this.geomOperators.size(); i++){
       Notifier op = this.geomOperators[i];
       if(op === notifier){
         if(i < this.dirtyPoint)
           this.dirtyPoint = i;
-        // for(Integer j=i; j<this.geomOperators.size; j++){
+        // for(Integer j=i; j<this.geomOperators.size(); j++){
         //   if(this.cachePoints[j] != null)
         //     this.cachePoints[j].invalidate();
         // }
@@ -120,15 +120,15 @@ function GeometrySet GeometryStack.evaluate!(EvalContext context) {
   AutoProfilingEvent p(FUNC);
 
   // this.dirtyPoint = 0;// force evaluation all the time.(disable caching)
-  if(this.dirtyPoint < this.geomOperators.size){
-    for(Integer i=this.dirtyPoint; i<this.geomOperators.size; i++){
+  if(this.dirtyPoint < this.geomOperators.size()){
+    for(Integer i=this.dirtyPoint; i<this.geomOperators.size(); i++){
       GeometryOperator op = this.geomOperators[i];
 
       // Now check the geometries if they have the attributes required by the next operation.
       Boolean debug = true;
       if(debug){
         UInt32 deps[String] = op.getAttributeInteractions();
-        for(Integer k=0; k<this.geomSet.size; k++){
+        for(Integer k=0; k<this.geomSet.size(); k++){
           String missingAttributes[];
           for(key, value in deps){
             if(value == AttrMode_Read || value == AttrMode_ReadWrite){
@@ -137,7 +137,7 @@ function GeometrySet GeometryStack.evaluate!(EvalContext context) {
                 missingAttributes.push(key);
             }
           }
-          if(missingAttributes.size > 0){
+          if(missingAttributes.size() > 0){
             setError("Cannot evaluate '" + op.type() + "'. Geometry missing required attributes:" + missingAttributes);
             return this.geomSet;
           }
@@ -175,7 +175,7 @@ function GeometrySet GeometryStack.evaluate!(EvalContext context) {
         }
       }
     }
-    this.dirtyPoint = this.geomOperators.size;
+    this.dirtyPoint = this.geomOperators.size();
   }
 
   if(this.displayGeometries && (this.handle==null || this.geomSetVersion != this.geomSet.getVersion())){
@@ -243,7 +243,7 @@ function RiggingToolboxRegistry GeometryStack.getRiggingToolboxRegistry(){
 function JSONDictValue GeometryStack.saveJSON(PersistenceContext persistenceContext){
   JSONDictValue json();
   JSONArrayValue geomOperatorsData();
-  for(UInt32 i=0; i<this.geomOperators.size; i++){
+  for(UInt32 i=0; i<this.geomOperators.size(); i++){
     geomOperatorsData.add(this.geomOperators[i].saveJSON(persistenceContext));
   }
   json.set("geomOperators", geomOperatorsData);
@@ -258,7 +258,7 @@ function GeometryStack.loadJSON!(PersistenceContext persistenceContext, JSONDict
   JSONArrayValue geomOperatorsData = json.get("geomOperators");
   if(!geomOperatorsData)
     throw("Error loading GeometryStack. JSON does not include a geomOperators array :" + json);
-  for(UInt32 i=0; i<geomOperatorsData.size; i++){
+  for(UInt32 i=0; i<geomOperatorsData.size(); i++){
     JSONDictValue geomOperatorData = geomOperatorsData.get(i);
     String type = geomOperatorData.getString("type");
     GeometryOperator geomOp = registry.constructGeometryOperator(type);
@@ -339,7 +339,7 @@ function String GeometryStack.getDesc(String indent, Boolean includeGeometryTolo
   String desc;
   desc += indent + "GeometryStack { \n";
   desc += indent + "  geomOperators:[ \n";
-  for(Integer i=0; i<this.geomOperators.size; i++){
+  for(Integer i=0; i<this.geomOperators.size(); i++){
     desc += this.geomOperators[i].getDesc(indent+'    ') + "\n";
   }
   desc += indent + "  ],\n";

--- a/Ext/GeometryStack/Manipulation/Weightmap2.kl
+++ b/Ext/GeometryStack/Manipulation/Weightmap2.kl
@@ -145,12 +145,12 @@ function JSONDictValue Weightmap2.saveJSON(PersistenceContext persistenceContext
     // The binary file will live in the same folder as the dcc scene file. 
     FilePath binCacheFilePath = sceneFilePath.removeFileName() / FilePath(fileName);
     BinaryBlockWriter blockWriter(binCacheFilePath.string());
-    blockWriter.setNumBlocks(1+this.weightMapAttrs.size);
+    blockWriter.setNumBlocks(1+this.weightMapAttrs.size());
     BinaryBlockWriter headerWriter = blockWriter.beginWriteBlock('header');
     UInt32 numWeightmaps = this.weightMapAttrs.size();
     headerWriter.write(numWeightmaps.data, numWeightmaps.dataSize);
 
-    for(Integer i=0; i<this.weightMapAttrs.size; i++){
+    for(Integer i=0; i<this.weightMapAttrs.size(); i++){
       BinaryBlockWriter bodyWriter = blockWriter.beginWriteBlock('weightMap'+i);
       UInt32 numElements = this.weightMapAttrs[i].size();
       bodyWriter.write(numElements.data, numElements.dataSize);
@@ -162,10 +162,10 @@ function JSONDictValue Weightmap2.saveJSON(PersistenceContext persistenceContext
   else{
     // Save all the data directly into the JSON string.
     JSONArrayValue weightMapsData();
-    for(Integer i=0; i<this.weightMapAttrs.size; i++){
+    for(Integer i=0; i<this.weightMapAttrs.size(); i++){
       JSONArrayValue weightMapData();
       weightMapData.values.resize(this.weightMapAttrs[i].size());
-      for(Integer j=0; j<this.weightMapAttrs.size; j++)
+      for(Integer j=0; j<this.weightMapAttrs.size(); j++)
         weightMapData.values[j] = JSONNumberValue(this.weightMapAttrs[i].values[j]);
       weightMapsData.add(weightMapData);
     }
@@ -210,13 +210,13 @@ function Weightmap2.loadJSON!(PersistenceContext persistenceContext, JSONDictVal
   else{
     if(json.has("weightMapsData")){
       JSONArrayValue weightMapsData = json.get("weightMapsData");
-      this.weightMapAttrs.resize(weightMapsData.size);
-      for(Integer i=0; i<weightMapsData.size; i++){
+      this.weightMapAttrs.resize(weightMapsData.size());
+      for(Integer i=0; i<weightMapsData.size(); i++){
         JSONArrayValue weightMapData = weightMapsData.get(i);
         this.weightMapAttrs[i] = ScalarAttribute();
         this.weightMapAttrs[i].name = this.name;
         this.weightMapAttrs[i].resize(weightMapData.size());
-        for(Integer j=0; j<this.weightMapAttrs.size; j++)
+        for(Integer j=0; j<this.weightMapAttrs.size(); j++)
           this.weightMapAttrs[i].values[j] = weightMapData.getScalar(j);
       }
     }
@@ -258,7 +258,7 @@ function Boolean Weightmap2.isConnected(){
 /// \param index The index of the mesh in the weightmap. 
 function Weightmap2.connect!( PolygonMesh mesh, Xfo meshTransform, UInt32 index){
   report(this.name + ".connect:"+index);
-  if(this.weightMapAttrs.size <= index){
+  if(this.weightMapAttrs.size() <= index){
     UInt32 newNumMeshes = index + 1;
     this.meshes.resize(newNumMeshes);
     this.meshTransforms.resize(newNumMeshes);
@@ -301,8 +301,8 @@ function Weightmap2.display!(Boolean state){
       this.overlayMaterial = overlayShader.getOrCreateMaterial("weightMap");
       this.overlayMaterial.setUniform('u_color', this.color);
 
-      this.instances.resize(this.meshes.size);
-      for(Integer i=0; i<this.instances.size; i++){
+      this.instances.resize(this.meshes.size());
+      for(Integer i=0; i<this.instances.size(); i++){
         // create a shape for the mesh
         InlineMeshShape shape = InlineMeshShape(this.name+'Shape', this.meshes[i]);
         InlineTransform transform = StaticInlineTransform(this.name+'Transform', this.handle.getRootTransform(), this.meshTransforms[i]);
@@ -312,7 +312,7 @@ function Weightmap2.display!(Boolean state){
       }
     }
     else {
-      for(Integer i=0; i<this.instances.size; i++){
+      for(Integer i=0; i<this.instances.size(); i++){
         if(this.instances[i] != null && !this.instances[i].hasMaterial(this.overlayMaterial)){
           this.instances[i].addMaterial(this.overlayMaterial); 
         }
@@ -321,7 +321,7 @@ function Weightmap2.display!(Boolean state){
     }
   }
   else {
-    for(Integer i=0; i<this.instances.size; i++){
+    for(Integer i=0; i<this.instances.size(); i++){
       if(this.instances[i] != null && this.instances[i].hasMaterial(this.overlayMaterial)){
         this.instances[i].removeMaterial(this.overlayMaterial); 
       }
@@ -331,16 +331,16 @@ function Weightmap2.display!(Boolean state){
 
 /// Activate the Weightmap2 manipulator 
 function Weightmap2.activateManipulator!(){
-  if(this.instances.size == 0)
+  if(this.instances.size() == 0)
     this.display(true);
-  if(this.instances.size == 0){
+  if(this.instances.size() == 0){
     setError("Cannnot activate the Weightmap2 without a geometry assigned");
   }
   Ref<EventDispatcher> eventDispatcher = EventDispatcher_GetInstance();
   if(!eventDispatcher.hasManipulator(this.name+'PaintManipulator')){
     eventDispatcher.registerManipulator(this.name+'PaintManipulator', this.paintManipulator);
   }
-  for(Integer i=0; i<this.instances.size; i++){
+  for(Integer i=0; i<this.instances.size(); i++){
     if(!this.paintManipulator.hasTargetGeometry(this.instances[i]))
       this.paintManipulator.addTargetGeometry(this.instances[i]);
   }
@@ -353,7 +353,7 @@ function Weightmap2.activateManipulator!(){
 
 /// Deactivate the Weightmap2 manipulator 
 function Weightmap2.deactivateManipulator!(){
-  if(this.instances.size == 0)
+  if(this.instances.size() == 0)
     return;
   Ref<EventDispatcher> eventDispatcher = EventDispatcher_GetInstance();
   if(this.paintManipulator != null && eventDispatcher.activeManipulator() == this.name+'PaintManipulator'){

--- a/Ext/GeometryStack/Manipulation/Weightmap2.kl
+++ b/Ext/GeometryStack/Manipulation/Weightmap2.kl
@@ -75,7 +75,6 @@ The Weightmap2 is a helper object to facilitate the binding of weightmaps to geo
 require InlineDrawing;
 require FileIO;
 require JSON;
-require SpliceInterfaces;
 
 object Weightmap2 : Persistable, Detachable {
   /// The name of the weightmap, which is used as the name of the geometry attribute on the polygon mesh.

--- a/Ext/GeometryStack/Manipulation/Weightmap2.kl
+++ b/Ext/GeometryStack/Manipulation/Weightmap2.kl
@@ -148,14 +148,14 @@ function JSONDictValue Weightmap2.saveJSON(PersistenceContext persistenceContext
     blockWriter.setNumBlocks(1+this.weightMapAttrs.size());
     BinaryBlockWriter headerWriter = blockWriter.beginWriteBlock('header');
     UInt32 numWeightmaps = this.weightMapAttrs.size();
-    headerWriter.write(numWeightmaps.data, numWeightmaps.dataSize);
+    headerWriter.write(numWeightmaps.data(), numWeightmaps.dataSize());
 
     for(Integer i=0; i<this.weightMapAttrs.size(); i++){
       BinaryBlockWriter bodyWriter = blockWriter.beginWriteBlock('weightMap'+i);
       UInt32 numElements = this.weightMapAttrs[i].size();
-      bodyWriter.write(numElements.data, numElements.dataSize);
+      bodyWriter.write(numElements.data(), numElements.dataSize());
       Scalar data[] = this.weightMapAttrs[i].values;
-      bodyWriter.write(data.data, data.dataSize);
+      bodyWriter.write(data.data(), data.dataSize());
     }
     root.setString("fileName", fileName);
   }
@@ -187,18 +187,18 @@ function Weightmap2.loadJSON!(PersistenceContext persistenceContext, JSONDictVal
       // Now read the data back in in an arbitrary order. 
       BinaryBlockReader headerReader = blockReader.beginReadBlock('header');
       UInt32 numWeightmaps = 0;
-      headerReader.read(numWeightmaps.data, numWeightmaps.dataSize);
+      headerReader.read(numWeightmaps.data(), numWeightmaps.dataSize());
       this.weightMapAttrs.resize(numWeightmaps);
 
       for(Integer i=0; i<numWeightmaps; i++){
         BinaryBlockReader bodyReader = blockReader.beginReadBlock('weightMap'+i);
         if(bodyReader){
           UInt32 numElements = 0;
-          bodyReader.read(numElements.data, numElements.dataSize);
+          bodyReader.read(numElements.data(), numElements.dataSize());
           this.weightMapAttrs[i] = ScalarAttribute();
           this.weightMapAttrs[i].name = this.name;
           this.weightMapAttrs[i].resize(numElements);
-          bodyReader.read(this.weightMapAttrs[i].values.data, this.weightMapAttrs[i].values.dataSize);
+          bodyReader.read(this.weightMapAttrs[i].values.data(), this.weightMapAttrs[i].values.dataSize());
         }
       }
       this.loaded = true;

--- a/Ext/GeometryStack/Modifiers/BlendShapesModifier.kl
+++ b/Ext/GeometryStack/Modifiers/BlendShapesModifier.kl
@@ -575,9 +575,9 @@ function BlendShapesModifier.saveTargetsToBinCache(FilePath binCachefile) {
     for(UInt32 j=0; j<this.targets[i].size(); j++){
       BinaryBlockWriter targetWriter = targetSetWriter.beginWriteBlock('target'+j);
       UInt32 count = this.targets[i][j].size();
-      targetWriter.write(count.data, count.dataSize);
-      targetWriter.write(this.targets[i][j].indices.data, this.targets[i][j].indices.dataSize);
-      targetWriter.write(this.targets[i][j].deltas.data, this.targets[i][j].deltas.dataSize);
+      targetWriter.write(count.data(), count.dataSize());
+      targetWriter.write(this.targets[i][j].indices.data(), this.targets[i][j].indices.dataSize());
+      targetWriter.write(this.targets[i][j].deltas.data(), this.targets[i][j].deltas.dataSize());
     }
   }
 }
@@ -594,10 +594,10 @@ function BlendShapesModifier.loadTargetsFromBinCache!(FilePath binCachefile) {
     for(UInt32 j=0; j<this.targets[i].size(); j++){
       BinaryBlockReader targetReader = targetSetReader.beginReadBlock('target'+j);
       UInt32 count = 0;
-      targetReader.read(count.data, count.dataSize);
+      targetReader.read(count.data(), count.dataSize());
       this.targets[i][j].resize(count);
-      targetReader.read(this.targets[i][j].indices.data, this.targets[i][j].indices.dataSize);
-      targetReader.read(this.targets[i][j].deltas.data, this.targets[i][j].deltas.dataSize);
+      targetReader.read(this.targets[i][j].indices.data(), this.targets[i][j].indices.dataSize());
+      targetReader.read(this.targets[i][j].deltas.data(), this.targets[i][j].deltas.dataSize());
     }
   }
 }

--- a/Ext/GeometryStack/Modifiers/BlendShapesModifier.kl
+++ b/Ext/GeometryStack/Modifiers/BlendShapesModifier.kl
@@ -28,7 +28,7 @@ struct BlendShapesModifier_Target {
 };
 
 function UInt32 BlendShapesModifier_Target.size(){
-  return this.indices.size;
+  return this.indices.size();
 }
 
 function BlendShapesModifier_Target.resize!(UInt32 size){
@@ -83,7 +83,7 @@ function UInt32[String] BlendShapesModifier.getAttributeInteractions(){
 
 inline String BlendShapesModifier_getNameFromPath(String pathStr) {
   String path[] = pathStr.split('/');
-  return path[path.size-1];
+  return path[path.size()-1];
 }
 
 /// Loads the targets from the alembic file
@@ -141,7 +141,7 @@ function BlendShapesModifier.loadTargetsFromAlembic!(FilePath expandedPath){
     }
   }
   UInt32 targetCount;
-  for(UInt32 i=0; i<this.targets.size; i++){
+  for(UInt32 i=0; i<this.targets.size(); i++){
     if(i==0)
       targetCount = this.targets[i].size();
     if(this.targets[i].size() == 0){
@@ -312,8 +312,8 @@ function BlendShapesModifier.addTargetGeometry!(UInt32 geomIndex, Geometry targe
 
     referencePointCount = targetMesh.pointCount();
   }
-  UInt32 targetPointCount = this.targets[geomIndex][targetIndex].indices.size;
-  report("addTargetGeometry:" + geomIndex +":" + this.targets[geomIndex].size + ":" + Scalar(targetPointCount)/Scalar(referencePointCount));
+  UInt32 targetPointCount = this.targets[geomIndex][targetIndex].indices.size();
+  report("addTargetGeometry:" + geomIndex +":" + this.targets[geomIndex].size() + ":" + Scalar(targetPointCount)/Scalar(referencePointCount));
   this.sparcity += Scalar(targetPointCount)/Scalar(referencePointCount);
   this.targetCount ++;
 }
@@ -381,8 +381,8 @@ operator blendShapesModifier_deformGeometries<<<index>>>(
   io UInt32 numActiveShapes
 ){
   AutoProfilingEvent p(FUNC);
-  if(targets[index].size != weights.size()){
-    report("BlendShapesModifier cannot evaluate because the number of weights:" + weights.size() + " does not match the number of targets:" + targets[index].size);
+  if(targets[index].size() != weights.size()){
+    report("BlendShapesModifier cannot evaluate because the number of weights:" + weights.size() + " does not match the number of targets:" + targets[index].size());
     return;
   }
   Geometry geom = geomSet.get(index);
@@ -400,7 +400,7 @@ operator blendShapesModifier_deformGeometries<<<index>>>(
     vertexColorsAttr.values = newColors;
   }
 
-  for(UInt32 i=0; i<targets[index].size; i++){
+  for(UInt32 i=0; i<targets[index].size(); i++){
     if(weights[i] > shapeThreshold){
       //AutoProfilingEvent p_targ("Target:" + i);
       if(!mesh){
@@ -434,8 +434,8 @@ operator blendShapesModifier_deformGeometries<<<index>>>(
 
 function BlendShapesModifier.evaluate!(EvalContext context, io GeometrySet geomSet){
   AutoProfilingEvent p(FUNC);
-  if(this.targets.size != geomSet.size()){
-    setError("BlendShapesModifier cannot evaluate because the number of geoms:" + geomSet.size() + " does not match the number of targets:" + this.targets.size);
+  if(this.targets.size() != geomSet.size()){
+    setError("BlendShapesModifier cannot evaluate because the number of geoms:" + geomSet.size() + " does not match the number of targets:" + this.targets.size());
     return;
   }
 
@@ -476,7 +476,7 @@ function BlendShapesModifier.setupRendering!(io GeometrySet geomSet){
   // Now setup the rendering
   InlineShader shader = this.handle.getDrawing().registerShader(OGLVertexColorOverlayShader2('BlendShapesModifierShader', 'blendShapes_vertexColors'));
   InlineMaterial material = shader.getOrCreateMaterial("BlendShapesModifierMaterial");
-  for(Integer geomId=0; geomId<geomSet.size; geomId++){
+  for(Integer geomId=0; geomId<geomSet.size(); geomId++){
     PolygonMesh mesh = geomSet.get(geomId);
     if(mesh){
       String name = "BlendShapesModifier_" + String(geomId);
@@ -499,7 +499,7 @@ function JSONDictValue BlendShapesModifier.saveJSON(PersistenceContext persisten
   json.setBoolean('displayDebugging', this.displayDebugging);
 
   JSONArrayValue targetGeometryNamesData();
-  for(Integer i=0; i<this.targetGeometryNames.size; i++)
+  for(Integer i=0; i<this.targetGeometryNames.size(); i++)
     targetGeometryNamesData.addString(this.targetGeometryNames[i]);
   json.set('targetGeometryNames', targetGeometryNamesData);
 
@@ -556,9 +556,9 @@ function BlendShapesModifier.loadJSON!(PersistenceContext persistenceContext, JS
     }
 
 
-    if(this.targets.size > 0){
-      this.targetColors.resize(this.targets[0].size);
-      for (Integer i = 0; i < this.targets[0].size; i++){
+    if(this.targets.size() > 0){
+      this.targetColors.resize(this.targets[0].size());
+      for (Integer i = 0; i < this.targets[0].size(); i++){
         this.targetColors[i] = randomColor(6754, i, 0.25);
       }
     }
@@ -568,11 +568,11 @@ function BlendShapesModifier.loadJSON!(PersistenceContext persistenceContext, JS
 function BlendShapesModifier.saveTargetsToBinCache(FilePath binCachefile) {
   report("saveTargetsToBinCache:" + binCachefile.string());
   BinaryBlockWriter blockWriter(binCachefile.string());
-  blockWriter.setNumBlocks(this.targets.size);
+  blockWriter.setNumBlocks(this.targets.size());
 
-  for(UInt32 i=0; i<this.targets.size; i++){
-    BinaryBlockWriter targetSetWriter = blockWriter.beginWriteBlock('targetSet'+i, this.targets[i].size);
-    for(UInt32 j=0; j<this.targets[i].size; j++){
+  for(UInt32 i=0; i<this.targets.size(); i++){
+    BinaryBlockWriter targetSetWriter = blockWriter.beginWriteBlock('targetSet'+i, this.targets[i].size());
+    for(UInt32 j=0; j<this.targets[i].size(); j++){
       BinaryBlockWriter targetWriter = targetSetWriter.beginWriteBlock('target'+j);
       UInt32 count = this.targets[i][j].size();
       targetWriter.write(count.data, count.dataSize);
@@ -587,11 +587,11 @@ function BlendShapesModifier.loadTargetsFromBinCache!(FilePath binCachefile) {
   BinaryBlockReader blockReader(binCachefile.string());
   UInt64 numBlocks = blockReader.getNumBlocks();
   this.targets.resize(UInt32(numBlocks));
-  for(UInt32 i=0; i<this.targets.size; i++){
+  for(UInt32 i=0; i<this.targets.size(); i++){
     BinaryBlockReader targetSetReader = blockReader.beginReadBlock('targetSet'+i);
     UInt64 numTargets = targetSetReader.getNumBlocks();
     this.targets[i].resize(UInt32(numTargets));
-    for(UInt32 j=0; j<this.targets[i].size; j++){
+    for(UInt32 j=0; j<this.targets[i].size(); j++){
       BinaryBlockReader targetReader = targetSetReader.beginReadBlock('target'+j);
       UInt32 count = 0;
       targetReader.read(count.data, count.dataSize);
@@ -609,9 +609,9 @@ function String BlendShapesModifier.getDesc(String indent) {
   desc += indent + "{\n";
   desc += indent + "  type: "+ this.type() + ",\n";
   desc += indent + "  filePath: "+ this.filePath + "\n";
-  desc += indent + "  refGeoms: "+ this.targets.size + "\n";
-  for(Integer i=0; i<this.targets.size; i++)
-    desc += indent + "    blendTargets: "+ + i +":" + this.targets[i].size + "\n";
+  desc += indent + "  refGeoms: "+ this.targets.size() + "\n";
+  for(Integer i=0; i<this.targets.size(); i++)
+    desc += indent + "    blendTargets: "+ + i +":" + this.targets[i].size() + "\n";
   desc += indent + "}";
   return desc;
 }

--- a/Ext/GeometryStack/Modifiers/SkinningModifier.kl
+++ b/Ext/GeometryStack/Modifiers/SkinningModifier.kl
@@ -60,13 +60,13 @@ function UInt32[String] SkinningModifier.getAttributeInteractions(){
 }
 
 function SkinningModifier.setReferencePose!(Mat44 referencePose[]){
-  this.invReferencePose.resize(referencePose.size);
-  this.deformerColors.resize(referencePose.size);
-  for (Integer i = 0; i < referencePose.size; i++){
+  this.invReferencePose.resize(referencePose.size());
+  this.deformerColors.resize(referencePose.size());
+  for (Integer i = 0; i < referencePose.size(); i++){
     this.invReferencePose[i] = referencePose[i].inverse();
     this.deformerColors[i] = randomColor(87655, i, 0.15);
   }
-  this.skinningMatrices.resize(referencePose.size);
+  this.skinningMatrices.resize(referencePose.size());
   this.pose = referencePose;
 }
 
@@ -74,8 +74,8 @@ function SkinningModifier.setSkeleton!(Skeleton skeleton){
   this.skeleton = skeleton;
   Size deformerIndices[] = skeleton.getDeformerIndices();
   Mat44 referencePose[];
-  referencePose.resize(deformerIndices.size);
-  for (Integer i = 0; i < deformerIndices.size; i++){
+  referencePose.resize(deformerIndices.size());
+  for (Integer i = 0; i < deformerIndices.size(); i++){
     referencePose[i] = skeleton.getBone(deformerIndices[i]).referencePose.toMat44();
   }
   this.setReferencePose(referencePose);
@@ -252,8 +252,8 @@ function SkinningModifier.evaluate!(EvalContext context, io GeometrySet geomSet)
         throw("No skeleton found in geometry set");
     }
 
-    this.bindShapeTransforms.resize(geomSet.size);
-    for(Integer i=0; i<geomSet.size; i++){
+    this.bindShapeTransforms.resize(geomSet.size());
+    for(Integer i=0; i<geomSet.size(); i++){
       Geometry geometry = geomSet.get(i);
       Ref<GeometryAttributes> attributes = geometry.getAttributes();
       if(!attributes.has("skinningData")){
@@ -276,11 +276,11 @@ function SkinningModifier.evaluate!(EvalContext context, io GeometrySet geomSet)
   }
 
   if(this.poseDirty){
-    if(this.pose.size != this.invReferencePose.size){
-      report('Warning: Pose count does not match the reference pose count. referencePose:' + this.invReferencePose.size + " != pose:" + this.pose.size + ". Skinning disabled");
+    if(this.pose.size() != this.invReferencePose.size()){
+      report('Warning: Pose count does not match the reference pose count. referencePose:' + this.invReferencePose.size() + " != pose:" + this.pose.size() + ". Skinning disabled");
       return;
     }
-    for (Integer i = 0; i < this.pose.size; i++) {
+    for (Integer i = 0; i < this.pose.size(); i++) {
       this.skinningMatrices[i] = this.pose[i] * this.invReferencePose[i];
     }
     this.poseDirty = false;
@@ -310,7 +310,7 @@ function SkinningModifier.evaluate!(EvalContext context, io GeometrySet geomSet)
       this.setupRendering(geomSet);
 
     Pose pose(this.skeleton);
-    for (Integer i = 0; i < this.pose.size; i++) {
+    for (Integer i = 0; i < this.pose.size(); i++) {
       pose.setBoneXfo(i, this.pose[i]);
     }
     ISkeleton iskeleton = this.skeleton;
@@ -369,7 +369,7 @@ function SkinningModifier.setupRendering!(io GeometrySet geomSet){
   InlineShader shader = this.handle.getDrawing().registerShader(OGLVertexColorOverlayShader2('SkinningModifierShader', 'skinning_vertexColors'));
   InlineMaterial material = shader.getOrCreateMaterial("SkinningModifierMaterial");
 
-  for(Integer geomId=0; geomId<geomSet.size; geomId++){
+  for(Integer geomId=0; geomId<geomSet.size(); geomId++){
     PolygonMesh mesh = geomSet.get(geomId);
     if(mesh){
       if(!mesh.has("vertexColors")){

--- a/Ext/GeometryStack/Notifier.kl
+++ b/Ext/GeometryStack/Notifier.kl
@@ -14,7 +14,7 @@ object Notifier {
 };
 
 function Notifier.addListener!(Listener listener){
-  for(Integer i=0; i<this.listeners.size; i++){
+  for(Integer i=0; i<this.listeners.size(); i++){
     if(this.listeners[i] === listener)
       return;
   }
@@ -22,12 +22,12 @@ function Notifier.addListener!(Listener listener){
 }
 
 function Notifier.removeListener!(Listener listener){
-  for(Integer i=0; i<this.listeners.size; i++){
+  for(Integer i=0; i<this.listeners.size(); i++){
     if(this.listeners[i] === listener){
-      for(Integer j=i; i<this.listeners.size-1; i++){
+      for(Integer j=i; i<this.listeners.size()-1; i++){
         this.listeners[j] = this.listeners[j+1];
       }
-      this.listeners.resize(this.listeners.size-1);
+      this.listeners.resize(this.listeners.size()-1);
       break;
     }
   }
@@ -35,7 +35,7 @@ function Notifier.removeListener!(Listener listener){
 
 
 function Notifier.notify(String type, String data){
-  for(Integer i=0; i<this.listeners.size; i++){
+  for(Integer i=0; i<this.listeners.size(); i++){
     // Cast the listener to an non-const value.
     Ref<Listener> listener = this.listeners[i];
     listener.notify(this, type, data);

--- a/Ext/Kinematics/solveNCFIK.kl
+++ b/Ext/Kinematics/solveNCFIK.kl
@@ -46,7 +46,7 @@ function Xfo[] solveNCFIK(
     boneLengths[i] = boneVectors[i].length();
     remainingChainLength += abs(boneLengths[i] /* basePose[i].sc.x*/);
   }
-  Integer lastBoneIndex = basePose.size-1;
+  Integer lastBoneIndex = basePose.size()-1;
   Vec3 fkChainTip = basePose[lastBoneIndex].tr;
   Vec3 chainRootPos = basePose[0].tr;
 

--- a/Ext/Math/bezierXfo.kl
+++ b/Ext/Math/bezierXfo.kl
@@ -65,7 +65,7 @@ inline BezierXfo.setKnots!(Xfo knots[]) {
 
 // Sets a single kont value in the curve.
 inline BezierXfo.setKnot!(UInt32 index, Xfo knot) {
-  if(this.knots.size <= index)
+  if(this.knots.size() <= index)
     this.knots.resize(index+1);
   this.knots[index] = knot;
 }

--- a/Tests/GeometryStack/DCCSetupScripts/Maya/MayaSplice_Skinning_DeltaMush_Wrap.py
+++ b/Tests/GeometryStack/DCCSetupScripts/Maya/MayaSplice_Skinning_DeltaMush_Wrap.py
@@ -108,7 +108,7 @@ cmds.connectAttr(influencePoseNode + '.stack', influenceMushNode + '.stack')
 
 influenceEvalNode = cmds.createNode("spliceMayaNode", name = "tubeCharacter_Eval")
 
-cmds.fabricSplice('addInputPort', influenceEvalNode, json.dumps({'portName':'stack', 'dataType':'GeometryStack', 'extension':'RiggingToolbox', 'addSpliceMayaAttr':True, 'autoInitObjects': False}))
+cmds.fabricSplice('addIOPort', influenceEvalNode, json.dumps({'portName':'stack', 'dataType':'GeometryStack', 'extension':'RiggingToolbox', 'addSpliceMayaAttr':True, 'autoInitObjects': False}))
 cmds.fabricSplice('addOutputPort', influenceEvalNode, json.dumps({'portName':'eval', 'dataType':'Scalar', 'addMayaAttr': True}))
 
 


### PR DESCRIPTION
Changes to make RiggingToolbox functional in Fabric Engine 2.0 (Pablo) and Canvas.

- Fix 2.0 incompatibility issues. (Also see #8)
- Add parentheses to method calls to avoid deprecated syntax
- Some minor bugfixes
- Tested functionality by rebuilding graph from one of the examples, see [test video](https://twitter.com/Royn3D/status/658385300062904320)

Once merged next step would be adding Canvas presets and examples; other than that code seems to be fully functional right now.