### PR TITLE
Fixed casts that are illegal in 20160211-101701

### DIFF
--- a/Ext/GeometryStack/GeometryStack.kl
+++ b/Ext/GeometryStack/GeometryStack.kl
@@ -66,7 +66,7 @@ function GeometryStack.addAttributeDependency!(String from, String to) {
 }
 
 
-function GeometryStack.addGeometryOperator!(GeometryOperator op) {
+function GeometryStack.addGeometryOperator!(BaseGenerator op) {
   this.geomOperators.push(op);
   this.cachePoints.resize(this.geomOperators.size());
 
@@ -93,7 +93,8 @@ function GeometryStack.notify!(Notifier notifier, String type, String data) {
   switch(type){
   case 'changed':
     for(Integer i=0; i<this.geomOperators.size(); i++){
-      Notifier op = this.geomOperators[i];
+      BaseGenerator bg = this.geomOperators[i];
+      Notifier op = bg;
       if(op === notifier){
         if(i < this.dirtyPoint)
           this.dirtyPoint = i;


### PR DESCRIPTION
RiggingToolbox won't compile in the latest daily build. I believe it's related to the changes Peter talks about here: http://forums.fabricengine.com/discussion/242/please-fix-cast-vs-construct-in-kl-language

The error messages: 

> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:74:12: error: no resolution for constructor Notifier(GeometryOperator)
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:74:12: Candidates are:
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:74:12:   function Notifier(Notifier)
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:74:12:     Rejected because there is no conversion from GeometryOperator to Notifier
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:74:12:   function Notifier(Ref<Notifier>)
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:74:12:     Rejected because there is no conversion from GeometryOperator to Ref<Notifier>
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:74:12:   function Notifier()
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:74:12:     Rejected because number of parameters does not match number of arguments
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:74:12:   function Notifier(RTVal)
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:74:12:     Rejected because implicit conversion from GeometryOperator to RTVal is not allowed
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:75:6: error: 'notifier': symbol not found
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:96:16: error: no resolution for constructor Notifier(GeometryOperator)
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:96:16: Candidates are:
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:96:16:   function Notifier(Notifier)
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:96:16:     Rejected because there is no conversion from GeometryOperator to Notifier
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:96:16:   function Notifier(Ref<Notifier>)
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:96:16:     Rejected because there is no conversion from GeometryOperator to Ref<Notifier>
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:96:16:   function Notifier()
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:96:16:     Rejected because number of parameters does not match number of arguments
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:96:16:   function Notifier(RTVal)
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:96:16:     Rejected because implicit conversion from GeometryOperator to RTVal is not allowed
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:97:10: In binary === expression:
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:97:10:   In left-hand side:
> [FABRIC:MT] [RiggingToolbox] GeometryStack/GeometryStack.kl:97:10: error: 'op': symbol not found